### PR TITLE
Make all config fields optional

### DIFF
--- a/lua/better-type-hover/init.lua
+++ b/lua/better-type-hover/init.lua
@@ -1,9 +1,9 @@
 ---@class config
----@field fold_lines_after_line integer - default 30
+---@field fold_lines_after_line integer|nil - default 30
 ---@field openTypeDocKeymap string|nil - default <C-P>. Set to '' to disable
----@field keys_that_open_nested_types string[] - default <C-P>. Set to '' to disable
----@field types_to_not_expand string[] - if a type is in this list, a type hint letter wont appear next to it in the main_window
----@field fallback_to_old_on_anything_but_interface_and_type boolean -- default is true
+---@field keys_that_open_nested_types string[]|nil - default <C-P>. Set to '' to disable
+---@field types_to_not_expand string[]|nil - if a type is in this list, a type hint letter wont appear next to it in the main_window
+---@field fallback_to_old_on_anything_but_interface_and_type boolean|nil -- default is true
 
 local M = {}
 

--- a/lua/better-type-hover/init.lua
+++ b/lua/better-type-hover/init.lua
@@ -1,3 +1,10 @@
+---@class config
+---@field fold_lines_after_line integer - default 30
+---@field openTypeDocKeymap string|nil - default <C-P>. Set to '' to disable
+---@field keys_that_open_nested_types string[] - default <C-P>. Set to '' to disable
+---@field types_to_not_expand string[] - if a type is in this list, a type hint letter wont appear next to it in the main_window
+---@field fallback_to_old_on_anything_but_interface_and_type boolean -- default is true
+
 local M = {}
 
 ---@type config
@@ -42,13 +49,6 @@ M.main_window_key_hint_win_ids = {}
 function M.better_type_hover()
 	M.open_primary_window()
 end
-
----@class config
----@field fold_lines_after_line integer - default 30
----@field openTypeDocKeymap string|nil - default <C-P>. Set to '' to disable
----@field keys_that_open_nested_types string[] - default <C-P>. Set to '' to disable
----@field types_to_not_expand string[] - if a type is in this list, a type hint letter wont appear next to it in the main_window
----@field fallback_to_old_on_anything_but_interface_and_type boolean -- default is true
 
 ---@param config config|nil
 function M.setup(config)


### PR DESCRIPTION
Right now if you want to change one setting in `setup()`, you must change them all:
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/6f98bd5f-3030-45bc-9edd-326b11aef79e" />

This PR makes the config fields optional, so that only one can be changed without warning:
<img width="501" alt="image" src="https://github.com/user-attachments/assets/edc3004a-d629-4949-96ae-db7550b417fb" />
